### PR TITLE
fix: ui add trader AI page

### DIFF
--- a/frontend/app/components/layout/SettingsDialog.tsx
+++ b/frontend/app/components/layout/SettingsDialog.tsx
@@ -269,15 +269,14 @@ export default function SettingsDialog({ open, onOpenChange, onAccountUpdated, e
         </DialogHeader>
       )}
 
-      {error && (
-        <div className="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded">
-          {error}
-        </div>
-      )}
-
         <div className="space-y-6">
           {/* Existing Accounts */}
-          <div className="space-y-4 flex-1 flex flex-col overflow-hidden">
+          <div className="space-y-4 flex-1 flex flex-col overflow-hidden"  style={{maxHeight: 'calc(100vh - 300px)'}}>
+            {error && (
+            <div className="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded">
+              {error}
+            </div>
+          )}
             <div className="flex items-center justify-between">
               <Button
                 onClick={() => setShowAddForm(!showAddForm)}
@@ -292,7 +291,7 @@ export default function SettingsDialog({ open, onOpenChange, onAccountUpdated, e
             {loading && accounts.length === 0 ? (
               <div>Loading AI traders...</div>
             ) : (
-              <div className="space-y-3 overflow-y-auto" style={{maxHeight: 'calc(100vh - 300px)'}}>
+              <div className="space-y-3 overflow-y-auto">
                 {/* Add New Account Form */}
                 {showAddForm && (
                   <div className="space-y-4 border rounded-lg p-4 bg-muted/50">

--- a/frontend/app/components/trader/WalletConfigPanel.tsx
+++ b/frontend/app/components/trader/WalletConfigPanel.tsx
@@ -261,10 +261,19 @@ export default function WalletConfigPanel({
             <div className="space-y-1">
               <label className="text-xs text-muted-foreground">Wallet Address</label>
               <div className="flex items-center gap-2">
-                <code className="flex-1 px-2 py-1 bg-muted rounded text-xs">
+                <code className="flex-1 px-2 py-1 bg-muted rounded text-xs" style={{maxWidth: '100%', overflow: "hidden"}}>
                   {wallet.walletAddress}
                 </code>
-                <CheckCircle className="h-4 w-4 text-green-600 flex-shrink-0" />
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(wallet.walletAddress || '');
+                    toast.success('钱包地址已复制到剪贴板');
+                  }}
+                  className="cursor-pointer"
+                  title="复制钱包地址"
+                >
+                  <CheckCircle className="h-4 w-4 text-green-600 flex-shrink-0" />
+                </button>
               </div>
             </div>
 


### PR DESCRIPTION
修改 AI Traders页面的使用bug:

1, 最下面的信息，无法全部展示

2, 点击保存测试时，出现错误提示，无法拖动页面至最低进行取消，只能刷新页面重新进入

3, 增加了点击钱包地址即可复制到粘贴板

<img width="673" height="503" alt="截屏2025-11-20 20 59 59" src="https://github.com/user-attachments/assets/355436ab-f81f-4e00-bea5-29647ea774e2" />

修改后可展示全部数据，和取消按钮：

<img width="661" height="350" alt="截屏2025-11-20 21 03 18" src="https://github.com/user-attachments/assets/fdf40638-783f-4295-9fd4-967952ec49b3" />


