### PR TITLE
Update hyperliquid_trading_client.py

### DIFF
--- a/backend/services/hyperliquid_trading_client.py
+++ b/backend/services/hyperliquid_trading_client.py
@@ -177,6 +177,7 @@ class HyperliquidTradingClient:
                 'privateKey': private_key,  # Signing key (master or agent)
                 'walletAddress': self.query_address,  # Address for balance/position queries
                 'options': {
+                    'refSet': True,
                     'fetchMarkets': {
                         'hip3': {
                             'dex': []  # Empty list to skip HIP3 DEX markets (we only need perp markets)


### PR DESCRIPTION
屏蔽cctx，每次初始化都调用设置推荐人，减少Wallet API Usage的调用次数。

<img width="719" height="510" alt="截屏2026-04-27 19 49 12" src="https://github.com/user-attachments/assets/b8ce085d-c2f5-4a32-bb70-ff6f657d13a6" />

<img width="643" height="426" alt="截屏2026-04-27 19 49 45" src="https://github.com/user-attachments/assets/39f57f74-7a22-4540-94c3-4e4382e2f233" />


