### PR TITLE
Add optional Adanos sentiment prompt variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,16 @@ HYPERLIQUID_MAX_POSITION_VALUE_PER_ORDER=1000.0
 # that is already synced from Hyper Alpha Arena after the user signs in.
 # Only the base URL is needed here unless the deployment wants to override it.
 HYPER_INSIGHT_API_BASE_URL=https://hyper.akooi.com
+
+# =================================================================
+# Optional: Adanos Market Sentiment API
+# =================================================================
+# Enables prompt variables such as {adanos_sentiment} and
+# {BTC_adanos_sentiment}. Leave ADANOS_API_KEY empty to disable.
+ADANOS_API_KEY=
+ADANOS_DISABLE=0
+ADANOS_API_BASE=https://api.adanos.org/reddit/crypto/v1
+ADANOS_TIMEOUT_S=5
+ADANOS_TOTAL_TIMEOUT_S=20
+ADANOS_SYMBOL_MAX=8
+ADANOS_MAX_WORKERS=4

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,3 +20,8 @@ HYPERLIQUID_MAX_POSITION_VALUE_PER_ORDER=1000.0
 # =================================================================
 
 # Add your other environment variables below...
+
+# Optional Adanos Market Sentiment API for AI Trader prompt variables.
+# Enables {adanos_sentiment} and {BTC_adanos_sentiment}.
+ADANOS_API_KEY=
+ADANOS_DISABLE=0

--- a/backend/config/PROMPT_VARIABLES_REFERENCE.md
+++ b/backend/config/PROMPT_VARIABLES_REFERENCE.md
@@ -505,6 +505,30 @@ Deep analysis:
 
 ---
 
+## Adanos Market Sentiment Variables (Optional)
+
+Adanos variables add external crypto market sentiment from Reddit discussion
+when `ADANOS_API_KEY` is configured. If the key is missing, these variables
+resolve to an unavailable message and the prompt continues rendering.
+
+| Variable | Description |
+|----------|-------------|
+| `{adanos_sentiment}` | Sentiment summary for the selected symbols |
+| `{adanos_sentiment_14d}` | Selected-symbol summary using a custom lookback in days |
+| `{BTC_adanos_sentiment}` | BTC-specific Adanos sentiment summary |
+| `{ETH_adanos_sentiment_30d}` | ETH-specific summary using a custom lookback |
+
+Lookback suffixes use calendar days (`_1d` to `_365d`). The default is 7 days.
+
+Example:
+```
+=== EXTERNAL SENTIMENT ===
+{adanos_sentiment}
+{BTC_adanos_sentiment}
+```
+
+---
+
 ## Legacy Variables (Backward Compatibility)
 
 | Variable | Description | Recommended Alternative |

--- a/backend/config/PROMPT_VARIABLES_REFERENCE_ZH.md
+++ b/backend/config/PROMPT_VARIABLES_REFERENCE_ZH.md
@@ -505,6 +505,30 @@ BTC news (24h, 46 articles):
 
 ---
 
+## Adanos 市场情绪变量（可选）
+
+配置 `ADANOS_API_KEY` 后，Adanos 变量会向提示词注入基于 Reddit 讨论的
+外部加密市场情绪数据。如果没有配置 API key，变量会渲染为不可用提示，
+不会阻塞提示词生成。
+
+| 变量 | 描述 |
+|------|------|
+| `{adanos_sentiment}` | 当前选中币种的 Adanos 情绪摘要 |
+| `{adanos_sentiment_14d}` | 使用自定义天数窗口的选中币种摘要 |
+| `{BTC_adanos_sentiment}` | BTC 专属 Adanos 情绪摘要 |
+| `{ETH_adanos_sentiment_30d}` | 使用自定义天数窗口的 ETH 摘要 |
+
+时间窗口后缀使用日历天（`_1d` 到 `_365d`），默认 7 天。
+
+示例：
+```
+=== 外部情绪 ===
+{adanos_sentiment}
+{BTC_adanos_sentiment}
+```
+
+---
+
 ## 遗留变量（向后兼容）
 
 | 变量 | 描述 | 推荐替代 |

--- a/backend/config/prompt_generation_system_prompt.md
+++ b/backend/config/prompt_generation_system_prompt.md
@@ -186,6 +186,7 @@ name=RSI21(id=5) | period=1h | expr=RSI(close, 21) | desc=RSI with 21-period loo
 - `{trading_environment}` - Platform description (Hyperliquid Testnet/Mainnet)
 - `{selected_symbols_detail}` - List of symbols being monitored
 - `{news_section}` - Latest cryptocurrency news
+- `{adanos_sentiment}` / `{BTC_adanos_sentiment}` - Optional Adanos crypto market sentiment when `ADANOS_API_KEY` is configured
 - `{trigger_context}` - **IMPORTANT**: Trigger context information showing what triggered this AI decision (signal pool or scheduled interval), including signal details when triggered by signals
 
 ### Signal Pool System (IMPORTANT)

--- a/backend/services/adanos_sentiment.py
+++ b/backend/services/adanos_sentiment.py
@@ -1,0 +1,285 @@
+"""
+Optional Adanos Market Sentiment prompt variables.
+
+The integration is intentionally prompt-scoped: no API key means no runtime
+effect unless a template explicitly references an Adanos variable.
+"""
+
+import os
+import re
+from concurrent.futures import ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Set
+from urllib.parse import quote
+
+import requests
+
+
+DEFAULT_API_BASE = "https://api.adanos.org/reddit/crypto/v1"
+DEFAULT_LOOKBACK_DAYS = 7
+
+GLOBAL_PATTERN = re.compile(r"\{(adanos_sentiment(?:_(\d+)d)?)\}")
+SYMBOL_PATTERN = re.compile(r"\{([A-Za-z0-9]{1,20})_adanos_sentiment(?:_(\d+)d)?\}")
+
+
+@dataclass(frozen=True)
+class AdanosConfig:
+    api_base: str = DEFAULT_API_BASE
+    api_key: Optional[str] = None
+    request_timeout_s: float = 5.0
+    total_timeout_s: float = 20.0
+    max_symbols: int = 8
+    max_workers: int = 4
+
+    @classmethod
+    def from_env(cls) -> "AdanosConfig":
+        return cls(
+            api_base=(os.getenv("ADANOS_API_BASE") or DEFAULT_API_BASE)
+            .strip()
+            .rstrip("/"),
+            api_key=(os.getenv("ADANOS_API_KEY") or "").strip() or None,
+            request_timeout_s=float(os.getenv("ADANOS_TIMEOUT_S") or "5"),
+            total_timeout_s=float(os.getenv("ADANOS_TOTAL_TIMEOUT_S") or "20"),
+            max_symbols=max(1, int(os.getenv("ADANOS_SYMBOL_MAX") or "8")),
+            max_workers=max(1, int(os.getenv("ADANOS_MAX_WORKERS") or "4")),
+        )
+
+
+def adanos_prompt_variables_enabled(cfg: Optional[AdanosConfig] = None) -> bool:
+    if (os.getenv("ADANOS_DISABLE") or "").lower() in ("1", "true", "yes"):
+        return False
+    if cfg:
+        return bool(cfg.api_key)
+    return bool((os.getenv("ADANOS_API_KEY") or "").strip())
+
+
+def _parse_days(raw_days: Optional[str]) -> int:
+    if not raw_days:
+        return DEFAULT_LOOKBACK_DAYS
+    return min(365, max(1, int(raw_days)))
+
+
+def parse_adanos_variables(template_text: str) -> Dict[str, Dict[str, Any]]:
+    if not template_text:
+        return {}
+
+    variables: Dict[str, Dict[str, Any]] = {}
+    for match in GLOBAL_PATTERN.finditer(template_text):
+        var_name, days = match.groups()
+        variables[var_name] = {"symbol": None, "days": _parse_days(days)}
+
+    for match in SYMBOL_PATTERN.finditer(template_text):
+        symbol, days = match.groups()
+        var_name = f"{symbol}_adanos_sentiment" + (f"_{days}d" if days else "")
+        variables[var_name] = {"symbol": symbol.upper(), "days": _parse_days(days)}
+
+    return variables
+
+
+def _symbols_for_variables(
+    variables: Dict[str, Dict[str, Any]],
+    selected_symbols: List[str],
+    max_symbols: int,
+) -> List[str]:
+    symbols: List[str] = []
+    seen: Set[str] = set()
+
+    def add(symbol: str) -> None:
+        normalized = (
+            str(symbol).upper().strip().replace("/USDT", "").replace("-USDT", "")
+        )
+        if normalized and normalized not in seen and len(symbols) < max_symbols:
+            seen.add(normalized)
+            symbols.append(normalized)
+
+    for spec in variables.values():
+        if spec.get("symbol"):
+            add(spec["symbol"])
+
+    if any(spec.get("symbol") is None for spec in variables.values()):
+        for symbol in selected_symbols:
+            add(symbol)
+
+    return symbols
+
+
+def _date_window(days: int, today: Optional[date] = None) -> tuple[str, str]:
+    end = today or datetime.now(timezone.utc).date()
+    start = end - timedelta(days=days - 1)
+    return start.isoformat(), end.isoformat()
+
+
+def _fetch_symbol(symbol: str, days: int, cfg: AdanosConfig) -> Dict[str, Any]:
+    start, end = _date_window(days)
+    response = requests.get(
+        f"{cfg.api_base}/token/{quote(symbol, safe='')}",
+        headers={"X-API-Key": cfg.api_key or ""},
+        params={"from": start, "to": end},
+        timeout=cfg.request_timeout_s,
+    )
+    if response.status_code == 404:
+        return {"symbol": symbol, "found": False}
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError("Adanos response is not a JSON object")
+    return _normalize_payload(symbol, payload)
+
+
+def _first_value(payload: Dict[str, Any], *names: str) -> Any:
+    for name in names:
+        value = payload.get(name)
+        if value is not None:
+            return value
+    return None
+
+
+def _normalize_payload(symbol: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    data = payload.get("data")
+    source = data if isinstance(data, dict) else payload
+
+    bullish = _first_value(source, "bullish_pct", "bullish_percentage", "bullish_ratio")
+    bearish = _first_value(source, "bearish_pct", "bearish_percentage", "bearish_ratio")
+    if isinstance(bullish, float) and 0 <= bullish <= 1:
+        bullish *= 100
+    if isinstance(bearish, float) and 0 <= bearish <= 1:
+        bearish *= 100
+
+    return {
+        "symbol": str(source.get("symbol") or payload.get("symbol") or symbol).upper(),
+        "found": source.get("found", True),
+        "sentiment_score": _first_value(
+            source, "sentiment_score", "sentiment", "score"
+        ),
+        "buzz_score": _first_value(source, "buzz_score", "buzzScore"),
+        "mentions": _first_value(source, "mentions", "mention_count", "mentionCount"),
+        "bullish_pct": bullish,
+        "bearish_pct": bearish,
+        "trend": source.get("trend"),
+    }
+
+
+def _fetch_sentiment_rows(
+    requests_to_fetch: List[tuple[str, int]],
+    cfg: AdanosConfig,
+) -> tuple[Dict[tuple[str, int], Dict[str, Any]], List[str]]:
+    rows: Dict[tuple[str, int], Dict[str, Any]] = {}
+    errors: List[str] = []
+    if not requests_to_fetch:
+        return rows, errors
+
+    executor = ThreadPoolExecutor(
+        max_workers=min(cfg.max_workers, len(requests_to_fetch))
+    )
+    futures = {
+        executor.submit(_fetch_symbol, symbol, days, cfg): (symbol, days)
+        for symbol, days in requests_to_fetch
+    }
+    done, pending = wait(futures, timeout=cfg.total_timeout_s)
+
+    for future in done:
+        symbol, days = futures[future]
+        try:
+            rows[(symbol, days)] = future.result()
+        except Exception as exc:
+            errors.append(f"{symbol}/{days}d: {exc}")
+
+    for future in pending:
+        symbol, days = futures[future]
+        future.cancel()
+        errors.append(
+            f"{symbol}/{days}d: timed out after {cfg.total_timeout_s:.1f}s total budget"
+        )
+
+    executor.shutdown(wait=False, cancel_futures=True)
+    return rows, errors
+
+
+def _fmt_number(value: Any, suffix: str = "") -> str:
+    if isinstance(value, int):
+        return f"{value}{suffix}"
+    if isinstance(value, float):
+        return f"{value:.2f}{suffix}"
+    return "N/A"
+
+
+def _format_row(row: Dict[str, Any], days: int) -> str:
+    symbol = str(row.get("symbol") or "UNKNOWN").upper()
+    if row.get("found") is False:
+        return f"{symbol}: no Adanos sentiment available for the last {days}d."
+
+    return (
+        f"{symbol}: sentiment={_fmt_number(row.get('sentiment_score'))}, "
+        f"buzz={_fmt_number(row.get('buzz_score'))}, mentions={_fmt_number(row.get('mentions'))}, "
+        f"bullish={_fmt_number(row.get('bullish_pct'), '%')}, "
+        f"bearish={_fmt_number(row.get('bearish_pct'), '%')}, "
+        f"trend={row.get('trend') or 'N/A'}"
+    )
+
+
+def build_adanos_sentiment_context(
+    template_text: str,
+    selected_symbols: List[str],
+    *,
+    cfg: Optional[AdanosConfig] = None,
+) -> Dict[str, str]:
+    variables = parse_adanos_variables(template_text)
+    if not variables:
+        return {}
+
+    cfg = cfg or AdanosConfig.from_env()
+    if not adanos_prompt_variables_enabled(cfg):
+        return {
+            name: "Adanos sentiment unavailable: set ADANOS_API_KEY to enable this optional data source."
+            for name in variables
+        }
+
+    symbols = _symbols_for_variables(variables, selected_symbols, cfg.max_symbols)
+    allowed_symbols = set(symbols)
+    requests_to_fetch: List[tuple[str, int]] = []
+    seen_requests: Set[tuple[str, int]] = set()
+
+    def add_fetch(symbol: str, days: int) -> None:
+        key = (symbol, days)
+        if key not in seen_requests:
+            seen_requests.add(key)
+            requests_to_fetch.append(key)
+
+    for spec in variables.values():
+        days = int(spec["days"])
+        if spec.get("symbol"):
+            if spec["symbol"] in allowed_symbols:
+                add_fetch(spec["symbol"], days)
+        else:
+            for symbol in symbols:
+                add_fetch(symbol, days)
+
+    rows, errors = _fetch_sentiment_rows(requests_to_fetch, cfg)
+    context: Dict[str, str] = {}
+
+    for name, spec in variables.items():
+        days = int(spec["days"])
+        if spec.get("symbol"):
+            symbol = spec["symbol"]
+            row = rows.get((symbol, days))
+            context[name] = (
+                _format_row(row, days)
+                if row
+                else f"{symbol}: Adanos sentiment unavailable for the last {days}d."
+            )
+            continue
+
+        lines = [f"Adanos crypto sentiment ({days}d):"]
+        for symbol in symbols:
+            row = rows.get((symbol, days))
+            lines.append(
+                f"- {_format_row(row, days)}"
+                if row
+                else f"- {symbol}: Adanos sentiment unavailable."
+            )
+        if errors:
+            lines.append(f"Partial errors: {'; '.join(errors[:3])}")
+        context[name] = "\n".join(lines)
+
+    return context

--- a/backend/services/ai_decision_service.py
+++ b/backend/services/ai_decision_service.py
@@ -1088,6 +1088,21 @@ def _build_prompt_context(
             logger.warning(f"Failed to build news context: {e}", exc_info=True)
 
     # ============================================================================
+    # ADANOS MARKET SENTIMENT VARIABLES
+    # ============================================================================
+    # Process optional Adanos variables like {adanos_sentiment} and
+    # {BTC_adanos_sentiment}. This stays prompt-scoped and fail-open.
+    adanos_context = {}
+    if template_text:
+        try:
+            from services.adanos_sentiment import build_adanos_sentiment_context
+            adanos_context = build_adanos_sentiment_context(template_text, ordered_symbols)
+            if adanos_context:
+                logger.debug(f"Built Adanos sentiment context with {len(adanos_context)} variables")
+        except Exception as e:
+            logger.warning(f"Failed to build Adanos sentiment context: {e}", exc_info=True)
+
+    # ============================================================================
     # TRIGGER CONTEXT FORMATTING
     # ============================================================================
     # Format trigger context into structured text for AI prompt.
@@ -1402,6 +1417,8 @@ Regime Types:
         "recent_trades_summary": recent_trades_summary,
         # Trigger context (signal or scheduled trigger information)
         "trigger_context": trigger_context_text,
+        # Optional Adanos Market Sentiment prompt variables
+        "adanos_sentiment": adanos_context.get("adanos_sentiment", "N/A"),
         # K-line and technical indicator variables (dynamically generated)
         **kline_context,  # Merge K-line/indicator variables like {BTC_klines_15m}, {BTC_MACD_15m}, etc.
         # Market Regime classification variables (multi-timeframe)
@@ -1410,6 +1427,8 @@ Regime Types:
         **factor_context,
         # News intelligence variables like {BTC_news_sentiment}, {macro_news}, etc.
         **news_context,
+        # Adanos Market Sentiment variables like {adanos_sentiment}, {BTC_adanos_sentiment}
+        **adanos_context,
     }
 
 

--- a/backend/services/ai_prompt_generation_service.py
+++ b/backend/services/ai_prompt_generation_service.py
@@ -292,11 +292,13 @@ VALID_VARIABLE_PATTERNS = [
     # Context variables
     r"runtime_minutes", r"current_time_utc", r"trading_environment", r"selected_symbols_detail",
     r"trigger_context", r"news_section", r"output_format",
+    r"adanos_sentiment(?:_\d+d)?",
     # Market regime
     r"market_regime_description", r"trigger_market_regime",
     r"market_regime(?:_(?:1m|5m|15m|1h|4h|1d))?",
     # Symbol-specific patterns (BTC, ETH, SOL, etc.)
     r"[A-Z]+_market_data",
+    r"[A-Z][A-Z0-9]*_adanos_sentiment(?:_\d+d)?",
     r"[A-Z]+_klines_(?:1m|3m|5m|15m|30m|1h|2h|4h|8h|12h|1d|3d|1w|1M)",
     r"[A-Z]+_market_regime(?:_(?:1m|5m|15m|1h|4h|1d))?",
     # Technical indicators

--- a/backend/test_adanos_sentiment.py
+++ b/backend/test_adanos_sentiment.py
@@ -1,0 +1,220 @@
+import time
+from datetime import date
+
+from services import adanos_sentiment
+from services.adanos_sentiment import (
+    AdanosConfig,
+    _date_window,
+    build_adanos_sentiment_context,
+    parse_adanos_variables,
+)
+
+
+class _Response:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def test_parse_adanos_prompt_variables():
+    variables = parse_adanos_variables(
+        "{adanos_sentiment}\n{adanos_sentiment_14d}\n{BTC_adanos_sentiment}\n{ETH_adanos_sentiment_30d}"
+    )
+
+    assert variables == {
+        "adanos_sentiment": {"symbol": None, "days": 7},
+        "adanos_sentiment_14d": {"symbol": None, "days": 14},
+        "BTC_adanos_sentiment": {"symbol": "BTC", "days": 7},
+        "ETH_adanos_sentiment_30d": {"symbol": "ETH", "days": 30},
+    }
+
+
+def test_date_window_uses_inclusive_lookback_days():
+    assert _date_window(7, today=date(2026, 6, 27)) == ("2026-06-21", "2026-06-27")
+
+
+def test_disabled_adanos_variable_does_not_fetch(monkeypatch):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+    monkeypatch.setenv("ADANOS_DISABLE", "0")
+
+    context = build_adanos_sentiment_context("{BTC_adanos_sentiment}", ["BTC"])
+
+    assert context == {
+        "BTC_adanos_sentiment": (
+            "Adanos sentiment unavailable: set ADANOS_API_KEY to enable this optional data source."
+        )
+    }
+
+
+def test_builds_symbol_and_global_context(monkeypatch):
+    calls = []
+
+    def fake_get(url, headers, params, timeout):
+        calls.append(
+            {"url": url, "headers": headers, "params": params, "timeout": timeout}
+        )
+        symbol = url.rsplit("/", 1)[-1]
+        return _Response(
+            payload={
+                "data": {
+                    "symbol": symbol,
+                    "found": True,
+                    "sentiment_score": 0.31,
+                    "buzz_score": 64.2,
+                    "mention_count": 123,
+                    "bullish_ratio": 0.43,
+                    "bearish_ratio": 0.19,
+                    "trend": "rising",
+                }
+            }
+        )
+
+    monkeypatch.setattr(adanos_sentiment.requests, "get", fake_get)
+
+    context = build_adanos_sentiment_context(
+        "{adanos_sentiment}\n{BTC_adanos_sentiment}",
+        ["BTC", "ETH"],
+        cfg=AdanosConfig(
+            api_base="https://api.example.test/reddit/crypto/v1",
+            api_key="sk_test",
+            request_timeout_s=3,
+            total_timeout_s=10,
+            max_symbols=2,
+            max_workers=2,
+        ),
+    )
+
+    assert "Adanos crypto sentiment (7d):" in context["adanos_sentiment"]
+    assert (
+        "BTC: sentiment=0.31, buzz=64.20, mentions=123"
+        in context["BTC_adanos_sentiment"]
+    )
+    assert len(calls) == 2
+    assert calls[0]["headers"] == {"X-API-Key": "sk_test"}
+    assert set(calls[0]["params"]) == {"from", "to"}
+    assert calls[0]["timeout"] == 3
+
+
+def test_prompt_generation_validator_accepts_adanos_variables():
+    from services.ai_prompt_generation_service import _validate_variable
+
+    assert _validate_variable("adanos_sentiment")
+    assert _validate_variable("adanos_sentiment_14d")
+    assert _validate_variable("BTC_adanos_sentiment")
+    assert _validate_variable("ETH_adanos_sentiment_30d")
+
+
+def test_fetches_distinct_lookback_windows(monkeypatch):
+    calls = []
+
+    def fake_get(url, headers, params, timeout):
+        calls.append(params)
+        return _Response(
+            payload={
+                "symbol": "BTC",
+                "found": True,
+                "sentiment_score": 0.2,
+                "buzz_score": 20,
+                "mentions": 10,
+            }
+        )
+
+    monkeypatch.setattr(adanos_sentiment.requests, "get", fake_get)
+
+    context = build_adanos_sentiment_context(
+        "{BTC_adanos_sentiment}\n{BTC_adanos_sentiment_30d}",
+        ["BTC"],
+        cfg=AdanosConfig(api_key="sk_test", max_workers=1),
+    )
+
+    assert "BTC_adanos_sentiment" in context
+    assert "BTC_adanos_sentiment_30d" in context
+    assert len(calls) == 2
+    assert calls[0] != calls[1]
+
+
+def test_explicit_symbol_variables_respect_symbol_cap(monkeypatch):
+    calls = []
+
+    def fake_get(url, headers, params, timeout):
+        calls.append(url)
+        symbol = url.rsplit("/", 1)[-1]
+        return _Response(payload={"symbol": symbol, "found": True, "mentions": 1})
+
+    monkeypatch.setattr(adanos_sentiment.requests, "get", fake_get)
+
+    context = build_adanos_sentiment_context(
+        "{BTC_adanos_sentiment}\n{ETH_adanos_sentiment}\n{SOL_adanos_sentiment}",
+        [],
+        cfg=AdanosConfig(api_key="sk_test", max_symbols=2, max_workers=2),
+    )
+
+    assert len(calls) == 2
+    assert "BTC: sentiment=N/A" in context["BTC_adanos_sentiment"]
+    assert "ETH: sentiment=N/A" in context["ETH_adanos_sentiment"]
+    assert context["SOL_adanos_sentiment"] == (
+        "SOL: Adanos sentiment unavailable for the last 7d."
+    )
+
+
+def test_explicit_symbol_variables_have_priority_over_global_fanout(monkeypatch):
+    calls = []
+
+    def fake_get(url, headers, params, timeout):
+        symbol = url.rsplit("/", 1)[-1]
+        calls.append(symbol)
+        return _Response(payload={"symbol": symbol, "found": True, "mentions": 1})
+
+    monkeypatch.setattr(adanos_sentiment.requests, "get", fake_get)
+
+    context = build_adanos_sentiment_context(
+        "{adanos_sentiment}\n{SOL_adanos_sentiment}",
+        ["BTC", "ETH", "DOGE", "XRP"],
+        cfg=AdanosConfig(api_key="sk_test", max_symbols=2, max_workers=2),
+    )
+
+    assert set(calls) == {"SOL", "BTC"}
+    assert len(calls) == 2
+    assert "SOL: sentiment=N/A" in context["SOL_adanos_sentiment"]
+
+
+def test_404_is_rendered_as_no_data(monkeypatch):
+    monkeypatch.setattr(
+        adanos_sentiment.requests,
+        "get",
+        lambda *args, **kwargs: _Response(status_code=404),
+    )
+
+    context = build_adanos_sentiment_context(
+        "{DOGE_adanos_sentiment}",
+        ["DOGE"],
+        cfg=AdanosConfig(api_key="sk_test"),
+    )
+
+    assert context["DOGE_adanos_sentiment"] == (
+        "DOGE: no Adanos sentiment available for the last 7d."
+    )
+
+
+def test_total_timeout_returns_fail_open_context(monkeypatch):
+    def slow_fetch(*args, **kwargs):
+        time.sleep(0.1)
+        return {"symbol": "BTC", "found": True}
+
+    monkeypatch.setattr(adanos_sentiment, "_fetch_symbol", slow_fetch)
+
+    context = build_adanos_sentiment_context(
+        "{adanos_sentiment}",
+        ["BTC"],
+        cfg=AdanosConfig(api_key="sk_test", total_timeout_s=0.01, max_workers=1),
+    )
+
+    assert "- BTC: Adanos sentiment unavailable." in context["adanos_sentiment"]
+    assert "timed out after 0.0s total budget" in context["adanos_sentiment"]


### PR DESCRIPTION
## Summary

- Adds optional Adanos crypto sentiment prompt variables for AI Trader templates.
- Supports `{adanos_sentiment}`, `{adanos_sentiment_14d}`, `{BTC_adanos_sentiment}`, and `{BTC_adanos_sentiment_30d}`.
- Keeps the integration fail-open: without `ADANOS_API_KEY`, variables render an unavailable message and normal prompt rendering continues.

## Implementation notes

- Uses the current Adanos `/reddit/crypto/v1/token/{symbol}` endpoint with inclusive `from` / `to` dates.
- Bounds external calls with per-request and total timeouts plus limited concurrency.
- Prioritizes explicit symbol variables over global watchlist fanout when `ADANOS_SYMBOL_MAX` is reached.
- Does not change default trading prompts, execution, signal logic, database schema, or dependencies.

## Tests

- `uv run pytest test_adanos_sentiment.py -q`
- `uv run ruff check services/adanos_sentiment.py test_adanos_sentiment.py`
- `uv run black --check services/adanos_sentiment.py test_adanos_sentiment.py`
- `uv run python -m py_compile services/adanos_sentiment.py services/ai_decision_service.py services/ai_prompt_generation_service.py`
- `$autoreview`: clean, no accepted/actionable findings

Note: `uv run pytest -q` currently hits an existing `program_trader/test_module.py::test_timeout` failure/hang unrelated to this change; the focused Adanos test file passes.
