### PR TITLE
Fix: AI decision broadcast silently fails from background scheduler thread

### DIFF
--- a/backend/services/ai_decision_service.py
+++ b/backend/services/ai_decision_service.py
@@ -1,6 +1,7 @@
 """
 AI Decision Service - Handles AI model API calls for trading decisions
 """
+import asyncio
 import logging
 import random
 import json
@@ -2627,8 +2628,7 @@ def save_ai_decision(
         )
 
         # Broadcast AI decision update via WebSocket
-        import asyncio
-        from api.ws import broadcast_model_chat_update
+        from api.ws import broadcast_model_chat_update, manager
 
         try:
             broadcast_data = {
@@ -2650,15 +2650,20 @@ def save_ai_decision(
                 "decision_snapshot": decision_log.decision_snapshot,
                 "wallet_address": decision_log.wallet_address,
             }
-            
-            # Check if there's a running event loop
-            try:
-                loop = asyncio.get_running_loop()
-                # Event loop is running, create task
-                loop.create_task(broadcast_model_chat_update(broadcast_data))
-            except RuntimeError:
-                # No running event loop, run synchronously
-                asyncio.run(broadcast_model_chat_update(broadcast_data))
+
+            # save_ai_decision() is usually called from a BackgroundScheduler
+            # worker thread that has no event loop of its own. Running the
+            # coroutine with asyncio.run() there would execute it on a brand
+            # new loop, but the WebSocket connections live on the main
+            # FastAPI/uvicorn loop in a different thread, so sends would
+            # silently fail. schedule_task() hands the coroutine to that
+            # loop via run_coroutine_threadsafe (or the caller's loop if one
+            # is already running), which is the pattern the rest of the
+            # codebase uses for the same situation.
+            manager.schedule_task(
+                broadcast_model_chat_update(broadcast_data),
+                source="ai_decision",
+            )
         except Exception as broadcast_err:
             # Don't fail the save operation if broadcast fails
             logger.warning(f"Failed to broadcast AI decision update: {broadcast_err}")


### PR DESCRIPTION
## Summary
- `save_ai_decision()` runs on an apscheduler `BackgroundScheduler` worker thread (`backend/services/scheduler.py` uses the thread-based scheduler, not `AsyncIOScheduler`), so it has no event loop of its own.
- To broadcast the new decision over WebSocket, it checked `asyncio.get_running_loop()` and fell back to `asyncio.run(broadcast_model_chat_update(...))` when none was found.
- That avoids the raw `RuntimeError: no running event loop` crash, but `asyncio.run()` executes the coroutine on a **brand new** event loop created in the worker thread — while the actual `WebSocket` connections in `ConnectionManager.active_connections` belong to the main FastAPI/uvicorn event loop running in a different thread. Sending on those connections from an unrelated loop/thread doesn't work, so the broadcast is silently dropped (caught by the outer `except Exception` and logged as `WARNING: Failed to broadcast AI decision update: ...`), and the Model Chat panel never updates — matching the symptom described in #29.
- `ConnectionManager.schedule_task()` (`backend/api/ws.py:130`) already exists to solve exactly this: it hands the coroutine to the real running FastAPI loop via `asyncio.run_coroutine_threadsafe()` (with a safe thread-based fallback if that loop isn't available), and is already used this way in `asset_snapshot_service.py` and `hyperliquid_snapshot_service.py`. This PR routes `save_ai_decision()`'s broadcast through the same helper instead of its own ad-hoc loop handling.

Fixes #29

Note: I left the second broadcast block a few lines below (the bot push-notification `push_event_to_all_channels(db, results)` call) untouched — it passes the SQLAlchemy `db` session into the coroutine, and routing that through `schedule_task()` would run it on a different thread's loop than the one that owns `db`, which isn't safe to do without a closer look at how that session is used. Happy to follow up on that separately if it's also actionable.

## Test plan
- [x] `python -m py_compile backend/services/ai_decision_service.py backend/api/ws.py` passes
- [ ] Haven't been able to spin up the full stack (DB + Hyperliquid/Binance creds) locally to reproduce the original "no running event loop" log lines end-to-end — happy to verify further if a maintainer can point me at a lightweight way to run just the AI decision + WebSocket broadcast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ386AEgV8Z796N4TSJtPn